### PR TITLE
Add ESLint and lint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "browser": true,
+    "jquery": true
+  },
+  "extends": "airbnb-base/legacy"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "lint": "eslint ."
+  },
+  "devDependencies": {
+    "eslint": "^3.19.0",
+    "eslint-config-airbnb-base": "^11.1.3",
+    "eslint-plugin-import": "^2.2.0"
+  }
+}


### PR DESCRIPTION
This adds [ESLint](http://eslint.org/) to the project, along with the [Airbnb base legacy](https://www.npmjs.com/package/eslint-config-airbnb-base#eslint-config-airbnb-baselegacy) rules.

ESLint can either be installed into your editor, or run from the command line with:

```
npm install
npm run lint
```

These rules have *not* been applied to the existing files as there are errors beyond formatting and consistency. However, this should provide a base to apply these rules.

<img width="328" alt="screen shot 2017-04-08 at 17 44 46" src="https://cloud.githubusercontent.com/assets/1479528/24830728/75696a9c-1c83-11e7-8431-be3b5e4a1480.png">

(This PR has been raised in response to a conversation on [Reddit](https://www.reddit.com/r/javascript/comments/642btf/here_is_a_personal_project_id_like_to_share_with/))